### PR TITLE
c-ares 1.19.0

### DIFF
--- a/recipe/bld_output.bat
+++ b/recipe/bld_output.bat
@@ -1,6 +1,10 @@
+:: cmd
 @echo on
+echo "Building %PKG_NAME%."
+
 set CMAKE_CONFIG=Release
 
+:: Isolate the build.
 mkdir build_%CMAKE_CONFIG%
 pushd build_%CMAKE_CONFIG%
 
@@ -12,6 +16,8 @@ if "%PKG_NAME:~-6%" == "static" (
   set CARES_SHARED=ON
 )
 
+:: Generate the build files.
+echo "Generating the build files..."
 cmake -G"NMake Makefiles" ^
       -DCARES_STATIC:BOOL=%CARES_STATIC% ^
       -DCARES_SHARED:BOOL=%CARES_SHARED% ^
@@ -19,9 +25,18 @@ cmake -G"NMake Makefiles" ^
       -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
       "%SRC_DIR%"
 
+:: Build.
+echo "Building..."
 nmake
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1
+
+:: Install.
+echo "Installing..."
 nmake install
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1
 
 popd
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/build_output.sh
+++ b/recipe/build_output.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+echo "Building ${PKG_NAME}."
 
+
+# Isolate the build.
 mkdir build && cd build
 
 if [[ "$PKG_NAME" == *static ]]; then
@@ -14,6 +17,8 @@ if [[ "${target_platform}" == linux-* ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_AR=${AR}"
 fi
 
+# Generate the build files.
+echo "Generating the build files..."
 cmake ${CMAKE_ARGS} -G"$CMAKE_GENERATOR" \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="$PREFIX" \
@@ -24,4 +29,14 @@ cmake ${CMAKE_ARGS} -G"$CMAKE_GENERATOR" \
       -GNinja \
       ${SRC_DIR}
 
-ninja install
+# Build.
+echo "Building..."
+ninja || exit 1
+
+# Installing
+echo "Installing..."
+ninja install || exit 1
+
+# Error free exit!
+echo "Error free exit!"
+exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "c-ares" %}
 {% set version = "1.19.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: c-ares-split
   version: {{ version }}
 
 source:
-  url: https://c-ares.org/download/{{ name }}-{{ version }}.tar.gz
+  url: https://c-ares.org/download/c-ares-{{ version }}.tar.gz
   sha256: bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,24 @@
-{% set version = "1.18.1" %}
+{% set name = "c-ares" %}
+{% set version = "1.19.0" %}
 
 package:
-  name: c-ares
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://c-ares.org/download/c-ares-{{ version }}.tar.gz
-  sha256: 1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf
+  url: https://c-ares.org/download/{{ name }}-{{ version }}.tar.gz
+  sha256: bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3
 
 build:
   number: 0
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - cmake  # [win]
+    # cmake on unix depends on c-ares. This breaks the cycle.
+    - cmake-no-system  # [unix]
+    - ninja  # [unix]
 
 outputs:
   - name: c-ares
@@ -37,6 +46,7 @@ outputs:
         - if not exist %PREFIX%\\Library\\bin\\cares.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\cares.lib exit 1  # [win]
         - if exist %PREFIX%\\Library\\lib\\cares_static.lib exit 1  # [win]
+  
   - name: c-ares-static
     script: build_output.sh  # [unix]
     script: bld_output.bat  # [win]
@@ -64,6 +74,8 @@ about:
   license_family: MIT
   license_file: LICENSE.md
   summary: This is c-ares, an asynchronous resolver library
+  description: |
+    c-ares is a C library for asynchronous DNS requests (including name resolves).
   dev_url: https://github.com/c-ares/c-ares
   doc_url: https://c-ares.org/docs.html
 


### PR DESCRIPTION
Changelog: https://c-ares.org/changelog.html#1_19_0
- fixes CVE-2022-4904 https://github.com/c-ares/c-ares/pull/497 and https://github.com/c-ares/c-ares/pull/497/commits/ac596026e77244481fd68736ae7f15855803a08a

License: https://github.com/c-ares/c-ares/blob/cares-1_19_0/LICENSE.md
Requirements: 
- https://github.com/c-ares/c-ares/blob/cares-1_19_0/INSTALL.md
- https://github.com/c-ares/c-ares/blob/cares-1_19_0/CMakeLists.txt

Actions:
1. Add a general host env
2. Add description
3. Enhance build scripts