### PR TITLE
[PKG-2137] c-ares 1.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.19.0" %}
+{% set version = "1.19.1" %}
 
 package:
   name: c-ares-split
@@ -6,10 +6,9 @@ package:
 
 source:
   url: https://c-ares.org/download/c-ares-{{ version }}.tar.gz
-  sha256: bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3
+  sha256: 321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e
 
 build:
-  # trigger 1
   number: 0
 
 requirements:


### PR DESCRIPTION
It fixes CVEs:
- [CVE-2023-32067](https://github.com/c-ares/c-ares/security/advisories/GHSA-9g78-jv2r-p7vc). High. 0-byte UDP payload causes Denial of Service
- [CVE-2023-31147](https://github.com/c-ares/c-ares/security/advisories/GHSA-8r8p-23f3-64c2) Moderate. Insufficient randomness in generation of DNS query IDs
- [CVE-2023-31130](https://github.com/c-ares/c-ares/security/advisories/GHSA-x6mf-cxr9-8q6v). Moderate. Buffer Underwrite in ares_inet_net_pton()
- [CVE-2023-31124](https://github.com/c-ares/c-ares/security/advisories/GHSA-54xr-f67r-4pc4). Low. AutoTools does not set CARES_RANDOM_FILE during cross compilation

Changelog: https://c-ares.org/changelog.html#1_19_1 and https://github.com/c-ares/c-ares/releases/tag/cares-1_19_1
License: https://github.com/c-ares/c-ares/blob/cares-1_19_1/LICENSE.md
Requirements: 
- https://github.com/c-ares/c-ares/blob/cares-1_19_1/INSTALL.md
- https://github.com/c-ares/c-ares/blob/cares-1_19_1/CMakeLists.txt

Actions:
1. Remove a temporary comment `# trigger 1`
    