### PR TITLE
c-ares 1.34.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler("c") }}
     - cmake  # [win]
     # cmake on unix depends on c-ares. This breaks the cycle.
@@ -30,7 +31,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ stdlib('c') }}
-        # C++ requers for tests during a build
+        # C++ requers for tests during a build. Toolchain-proper
         - {{ compiler("cxx") }}
         - cmake  # [win]
         # cmake on unix depends on c-ares. This breaks the cycle.
@@ -57,7 +58,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ stdlib('c') }}
-        # https://github.com/c-ares/c-ares/blob/v1.34.5/CMakeLists.txt#L49
+        # C++ requers for tests during a build. Toolchain-proper
         - {{ compiler("cxx") }}
         - cmake  # [win]
         # cmake on unix depends on c-ares. This breaks the cycle.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.34.5" %}
+{% set version = "1.34.6" %}
 {% set name = "c-ares" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: dcd919635f01b7c8c9c2f5fb38063cd86500f7c6d4d32ecf4deff5e3497fb157
+  sha256: 4358939ff800b13b92f37d5fdda003718101faedfbdee792d6b79ddc1a53d890
 build:
   number: 0
 
@@ -30,7 +30,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ stdlib('c') }}
-        # https://github.com/c-ares/c-ares/blob/v1.34.5/CMakeLists.txt#L49
+        # C++ requers for tests during a build
         - {{ compiler("cxx") }}
         - cmake  # [win]
         # cmake on unix depends on c-ares. This breaks the cycle.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ stdlib('c') }}
-        # C++ requers for tests during a build. Toolchain-proper
+        # C++ required for tests during a build. Toolchain-proper
         - {{ compiler("cxx") }}
         - cmake  # [win]
         # cmake on unix depends on c-ares. This breaks the cycle.
@@ -58,7 +58,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ stdlib('c') }}
-        # C++ requers for tests during a build. Toolchain-proper
+        # C++ required for tests during a build. Toolchain-proper
         - {{ compiler("cxx") }}
         - cmake  # [win]
         # cmake on unix depends on c-ares. This breaks the cycle.


### PR DESCRIPTION
c-ares 1.34.6

**Destination channel:** {defaults}

### Links

- [{[PKG-11908](https://anaconda.atlassian.net/browse/PKG-11908)}](https://anaconda.atlassian.net/browse/PKG-11908) 
- [Upstream repository](https://github.com/c-ares/c-ares/tree/v1.34.6)
- [Upstream changelog/diff](https://github.com/c-ares/c-ares/compare/v1.34.5...v1.34.6)
- conda-forge | https://github.com/conda-forge/c-ares-feedstock
- Anaconda Recipes | https://github.com/AnacondaRecipes/c-ares-feedstock



### Explanation of changes:

- version updated 1.34.5 → 1.34.6
- added {{ stdlib('c') }} to top-level build requirements


[PKG-11908]: https://anaconda.atlassian.net/browse/PKG-11908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ