### PR TITLE
Win arm64

### DIFF
--- a/recipe/bld_output.bat
+++ b/recipe/bld_output.bat
@@ -34,6 +34,8 @@ if errorlevel 1 exit /b 1
 @REM https://github.com/c-ares/c-ares/blob/v1.34.5/CMakeLists.txt#L57
 if "%PKG_NAME:~-6%" == "static" (
 echo "Testing..."
+@REM Skip tests that fail due to environment limitations (IPv6, DNS ANY queries, localhost reverse lookup)
+set GTEST_FILTER=-*LiveGetHostByNameV6*:*LiveSearchANY*:*LiveGetLocalhostByAddrV4*
 ctest --output-on-failure
 if errorlevel 1 exit /b 1
 )


### PR DESCRIPTION
c-ares win-arm64 changes. 

https://anaconda.atlassian.net/browse/PKG-15378

- Skip tests that fail with cloudflare DNS (same as upstream)
- This is needed just for upcoming win-arm64 buildout, so nothing needs to be released. 